### PR TITLE
FIX packaging to produce the right sdist

### DIFF
--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -1,0 +1,36 @@
+name: Python Tests
+
+on:
+  push:
+    branches: main
+  pull_request:
+    paths-ignore:
+      - "doc/**"
+      
+jobs:
+  check-packaging:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.12
+    - name: Install discopat and tools
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install check-manifest .
+    - name: Check manifest
+      run: check-manifest
+    - name: Check submodules import
+      run: |
+        mkdir running_dir
+        cd running_dir
+        python -c "from discopat import metrics"
+

--- a/.github/workflows/packaging.yaml
+++ b/.github/workflows/packaging.yaml
@@ -1,4 +1,4 @@
-name: Python Tests
+name: Check Packaging
 
 on:
   push:
@@ -8,12 +8,7 @@ on:
       - "doc/**"
       
 jobs:
-  check-packaging:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9", "3.11", "3.12", "3.13", "3.14"]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+  checks:
     runs-on: ubuntu-latest
 
     steps:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+recursive-include discopat *.py
+
+prune docs
+prune examples
+prune tests
+prune assets
+exclude *.yaml
+exclude *.ini

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,10 @@
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-packages = ["discopat"]
+[tool.setuptools.packages.find]
+namespaces = false
+
+
 
 [project]
 name = "discopat"


### PR DESCRIPTION
In a new env, running `pip install discopat` does not include submodules.
This PR intend to fix this and add tests to make sure it is the case.